### PR TITLE
✨ Week2/feature/15-생성, 수정, 상세조회 시 더 자세한 정보를 리턴하도록 변경(수정 제외)

### DIFF
--- a/src/event/dto/event-detail.dto.ts
+++ b/src/event/dto/event-detail.dto.ts
@@ -1,0 +1,126 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ReviewDto } from 'src/review/dto/review.dto';
+import { EventDetailData, EventStatus } from '../type/event-detail-data.type';
+
+export class JoinedUserDto {
+  @ApiProperty({
+    description: 'user ID',
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: 'user 이름',
+    type: String,
+  })
+  name!: string;
+}
+
+export class EventDetailDto {
+  @ApiProperty({
+    description: '이벤트 ID',
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '호스트 ID',
+    type: Number,
+  })
+  hostId!: number;
+
+  @ApiProperty({
+    description: '이벤트 이름',
+    type: String,
+  })
+  title!: string;
+
+  @ApiProperty({
+    description: '이벤트 설명',
+    type: String,
+  })
+  description!: string;
+
+  @ApiProperty({
+    description: '이벤트가 속한 카테고리 ID',
+    type: Number,
+  })
+  categoryId!: number;
+
+  @ApiProperty({
+    description: '이벤트 도시 ID',
+    type: Number,
+  })
+  cityId!: number;
+
+  @ApiProperty({
+    description: '이벤트 시작 시간',
+    type: Date,
+  })
+  startTime!: Date;
+
+  @ApiProperty({
+    description: '이벤트 종료 시간',
+    type: Date,
+  })
+  endTime!: Date;
+
+  @ApiProperty({
+    description: '이벤트에 참여가능한 최대 인원',
+    type: Number,
+  })
+  maxPeople!: number;
+
+  @ApiProperty({
+    description: '이벤트의 현재 상태',
+    type: EventStatus,
+  })
+  status!: EventStatus;
+
+  @ApiProperty({
+    description: '참여하는 유저 목록',
+    type: [JoinedUserDto],
+  })
+  joinedUsers!: JoinedUserDto[];
+
+  @ApiProperty({
+    description: '이벤트의 리뷰 목록',
+    type: [ReviewDto],
+  })
+  reviews!: ReviewDto[];
+
+  static from(event: EventDetailData): EventDetailDto {
+    return {
+      id: event.id,
+      hostId: event.hostId,
+      title: event.title,
+      description: event.description,
+      categoryId: event.categoryId,
+      cityId: event.cityId,
+      startTime: event.startTime,
+      endTime: event.endTime,
+      maxPeople: event.maxPeople,
+      status: event.status,
+      joinedUsers: event.joinedUsers,
+      reviews: event.reviews,
+    };
+  }
+
+  static fromArray(events: EventDetailData[]): EventDetailDto[] {
+    return events.map((event) => this.from(event));
+  }
+}
+
+export class EventDetailListDto {
+  @ApiProperty({
+    description: '이벤트 목록',
+    type: [EventDetailDto],
+  })
+  events!: EventDetailDto[];
+
+  static from(events: EventDetailData[]): EventDetailListDto {
+    return {
+      events: EventDetailDto.fromArray(events),
+    };
+  }
+}

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -3,6 +3,7 @@ import {
   ApiNoContentResponse,
   ApiOkResponse,
   ApiOperation,
+  ApiTags,
 } from '@nestjs/swagger';
 import { EventService } from './event.service';
 import {
@@ -20,6 +21,7 @@ import { EventQuery } from './query/event.query';
 import { EventJoinOutPayload } from './payload/event-join-out.payload';
 
 @Controller('events')
+@ApiTags('Event API')
 export class EventController {
   constructor(private readonly eventService: EventService) {}
 

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -6,15 +6,16 @@ import {
 } from '@nestjs/common';
 import { EventRepository } from './event.repository';
 import { CreateEventPayload } from './payload/create-event.payload';
-import { EventDto, EventListDto } from './dto/event.dto';
+import { EventListDto } from './dto/event.dto';
 import { CreateEventData } from './type/create-event-data.type';
 import { EventQuery } from './query/event.query';
+import { EventDetailDto } from './dto/event-detail.dto';
 
 @Injectable()
 export class EventService {
   constructor(private readonly eventRepository: EventRepository) {}
 
-  async createEvent(payload: CreateEventPayload): Promise<EventDto> {
+  async createEvent(payload: CreateEventPayload): Promise<EventDetailDto> {
     const isCategoryExist = await this.eventRepository.isCategoryExist(
       payload.categoryId,
     );
@@ -55,23 +56,24 @@ export class EventService {
 
     const event = await this.eventRepository.createEvent(createData);
 
-    //host를 event 참여 인원에 추가
-    await this.eventRepository.joinUserToEvent({
-      eventId: event.id,
-      userId: event.hostId,
-    });
+    // eventRepository.createEvent로 옮김(issue15)
+    // //host를 event 참여 인원에 추가
+    // await this.eventRepository.joinUserToEvent({
+    //   eventId: event.id,
+    //   userId: event.hostId,
+    // });
 
-    return EventDto.from(event);
+    return EventDetailDto.from(event);
   }
 
-  async getEventById(eventId: number): Promise<EventDto> {
+  async getEventById(eventId: number): Promise<EventDetailDto> {
     const event = await this.eventRepository.getEventById(eventId);
 
     if (!event) {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
 
-    return EventDto.from(event);
+    return EventDetailDto.from(event);
   }
 
   async getEvents(query: EventQuery): Promise<EventListDto> {

--- a/src/event/type/event-detail-data.type.ts
+++ b/src/event/type/event-detail-data.type.ts
@@ -1,0 +1,32 @@
+export type EventDetailData = {
+  id: number;
+  hostId: number;
+  title: string;
+  description: string;
+  categoryId: number;
+  cityId: number;
+  startTime: Date;
+  endTime: Date;
+  maxPeople: number;
+  status: EventStatus;
+  joinedUsers: {
+    id: number;
+    name: string;
+  }[];
+  reviews: {
+    id: number;
+    eventId: number;
+    userId: number;
+    score: number;
+    title: string;
+    description: string | null;
+  }[];
+};
+
+export const EventStatus = {
+  PENDING: 'PENDING', // 시작 전
+  ONGOING: 'ONGOING', // 진행 중
+  COMPLETED: 'COMPLETED', // 종료
+};
+
+export type EventStatus = (typeof EventStatus)[keyof typeof EventStatus];

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,9 @@
 import { Controller, Delete, HttpCode, Param } from '@nestjs/common';
 import { UserService } from './user.service';
-import { ApiNoContentResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiNoContentResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @Controller('users')
+@ApiTags('User API')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 어떤 목적의 작업인가요?
  issue15 - 생성, 수정, 상세조회 시 더 자세한 정보를 리턴하도록 변경(수정 제외)

## Why
- 어떤 이유로 작업하셨나요?(Optional)
  week2 hw(additional)

## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?
  아직 event 수정 API를 안 만들어서, 수정하는 경우는 제외했습니다(나중에 할 예정)

  그리고 이벤트 생성 시 joinedUsers를 리턴하는 과정에서 질문이 있습니다!
  처음에는 생성 직후라 당연히 host만 참가한 상태일 것 같아 host만 넣어서 리턴하려다가, -a
  이벤트 생성한 후 해당 이벤트에서 유저 목록 가져오는 방식으로 일단 만들었습니다.  -b
  (이거때문에 호스트를 이벤트에 참여시키는 코드가 service에서 repository로 이동했어요 - 주석 처리한 부분)
  
  a랑 b 중에 뭐가 더 좋은 방법인지 궁금합니다

## Checklist
- Merge 나 Deploy 시 확인이 필요한 부분이 있다면 적어주세요.